### PR TITLE
Ability for custom width

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 | callback | function that will get called when the progress is done |
 | theme | What you want the progress bar/circle to look like |
 | color | What color (hex or rgb) do you want the progress loader to be. Defaults to a dark red. |
+| width | What width you want the linear progressbar to be. Default: 20vw |
 
 ##### Theme Options
 | Option | Info |
@@ -36,7 +37,7 @@ _**Examples:**_
  ```lua
         progressbar.start('Loading...', 20000, function ()
             print('DONE!!!!')
-        end, 'linear', '#ff0000')
+        end, 'linear', '#ff0000', '20vw')
  ```
 
  ```lua

--- a/client/client.lua
+++ b/client/client.lua
@@ -3,28 +3,33 @@ local queue = {}
 
 exports('initiate',function()
     local self = {}
-
-    self.start = function (message, miliseconds, cb, theme, color)
+    
+    self.start = function (message, miliseconds, cb, theme, color, width)
         if theme == nil then
             theme = "linear"
         end
-
+    
         if color == nil then
             color = 'rgb(124, 45, 45)'
         end
-
+        
+        if width == nil then
+            width = '20vw'
+        end
+    
         table.insert(queue, {
             message = message,
             callback = cb
         })
-
+    
         SetNuiFocus(true, false)
         SendNUIMessage({
             type = 'vp-open',
             message = message,
             mili = miliseconds,
             theme = theme,
-            color = color
+            color = color,
+            width = width
         })
     end
 

--- a/ui/app.js
+++ b/ui/app.js
@@ -11,7 +11,8 @@ createApp({
       interval: null,
       timeout: null,
       running: false,
-      maincolor: null
+      maincolor: null,
+      width: '20vw'
     };
   },
   mounted() {
@@ -37,6 +38,7 @@ createApp({
         this.theme = event.data.theme;
         this.time = event.data.mili;
         this.maincolor = event.data.color
+        this.width = event.data.width
         let that = this;
         running = true
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div id="app">
-      <div class="wrapper linear-progress" v-if="visible && theme == 'linear'" :style="{'--maincolor': maincolor}">
+      <div class="wrapper linear-progress" v-if="visible && theme == 'linear'" :style="{'--maincolor': maincolor, 'width':width}">
         <div
           class="loader"
           :style="`animation-name: growprogress; animation-duration: ${time}ms; animation-timing-function: linear;`"

--- a/ui/style.css
+++ b/ui/style.css
@@ -23,7 +23,6 @@ body {
   text-align: center;
   width: 20vw;
   height: 30px;
-
   position: absolute;
   left: 50%;
   bottom: 2%;
@@ -33,7 +32,7 @@ body {
 
 .linear-progress {
   position: absolute;
-  overflow: hidden;
+  /* overflow: hidden; */
   bottom: 200px;
   border-radius: 4px;
   background-color: rgba(87, 87, 87, 0.486);
@@ -74,6 +73,7 @@ body {
   left:50%;
   transform:translate(-50%,-50%);
   margin:0;
+  width: 100%;
 }
 
 @keyframes circleprogress {


### PR DESCRIPTION
**What this changes**
1. Minor bugfix for larger linear progressbar text
2. New argument for custom width.
 ```lua
        progressbar.start('Loading...', 20000, function ()
            print('DONE!!!!')
        end, 'linear', '#ff0000', '20vw')
 ```