### PR TITLE
Added exports for CancelNext and CancelAll

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -6,7 +6,7 @@ local function _internalStart(message, miliseconds, cb, theme, color, width, foc
     end
 
     if color == nil then
-        color = 'rgb(45, 5, 244)'
+        color = 'rgb(124, 45, 45)'
     end
     
     if width == nil then

--- a/client/client.lua
+++ b/client/client.lua
@@ -6,7 +6,7 @@ local function _internalStart(message, miliseconds, cb, theme, color, width, foc
     end
 
     if color == nil then
-        color = 'rgb(124, 45, 45)'
+        color = 'rgb(45, 5, 244)'
     end
     
     if width == nil then
@@ -46,6 +46,36 @@ AddEventHandler('__cfx_export_progressBars_startUI', function(callback)
     callback(function (time, text)
         _internalStart(text, time, nil, nil, nil, nil, false)
     end)
+end)
+
+exports('CancelNext', function(cb)
+    local cancelled = CancelNext()
+    if cb ~= nil then
+        cb(cancelled)
+    end
+end)
+
+function CancelNext()
+    local cancelled = {}
+    if queue[1] ~= nil then
+        if queue[1].focus ~= false then
+            SetNuiFocus(false, false)
+        end
+        SendNUIMessage({type = 'vp-cancel'})
+        cancelled = queue[1];
+        table.remove(queue, 1)
+    end
+    return cancelled;
+end
+
+exports('CancelAll', function(cb)
+    local cancelled = {}
+    while queue[1] ~= nil do
+        table.insert(cancelled, CancelNext())
+    end
+    if cb ~= nil then
+        cb(cancelled)
+    end
 end)
 
 RegisterNUICallback('ProgressFinished', function(args, nuicb)

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,5 +1,4 @@
 const { createApp } = Vue;
-
 createApp({
   data() {
     return {
@@ -12,7 +11,8 @@ createApp({
       timeout: null,
       running: false,
       maincolor: null,
-      width: '20vw'
+      width: "20vw",
+      cancelled: false,
     };
   },
   mounted() {
@@ -27,8 +27,8 @@ createApp({
   },
   computed: {
     counter() {
-      return Math.trunc((this.time - (this.currenttime))/1000)
-    }
+      return Math.trunc((this.time - this.currenttime) / 1000);
+    },
   },
   methods: {
     onMessage(event) {
@@ -37,26 +37,38 @@ createApp({
         this.message = event.data.message;
         this.theme = event.data.theme;
         this.time = event.data.mili;
-        this.maincolor = event.data.color
-        this.width = event.data.width
+        this.maincolor = event.data.color;
+        this.width = event.data.width;
+        this.cancelled = false;
         let that = this;
-        running = true
+        running = true;
 
         this.interval = setInterval(() => {
-          that.currenttime += 1000
+          that.currenttime += 1000;
         }, 1000);
 
         this.timeout = setTimeout(() => {
-          that.running = false
+          that.running = false;
           that.visible = false;
           clearInterval(that.interval);
-          that.currenttime = 0
-          that.interval = null
-          that.timeout = null
-          fetch(`https://${GetParentResourceName()}/ProgressFinished`, {
-            method: "POST"
-          });
+          that.currenttime = 0;
+          that.interval = null;
+          that.timeout = null;
+          if (!this.cancelled) {
+            fetch(`https://${GetParentResourceName()}/ProgressFinished`, {
+              method: "POST",
+            });
+          }
         }, event.data.mili);
+      }
+      if (event.data.type === "vp-cancel") {
+        this.cancelled = true;
+        this.running = false;
+        this.visible = false;
+        clearInterval(this.interval);
+        this.currenttime = 0;
+        this.interval = null;
+        this.timeout = null;
       }
     },
   },


### PR DESCRIPTION
There was no way to cancel an ongoing progress bar, this now introduces that functionality.

This adds the ability to cancel the next progress bar or all progress bars from export calls, with an optional callback function which returns the cancelled progressbar entries from queue.